### PR TITLE
fix: Send CI failures to tnl-squad instead of OpsGenie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,6 @@ jobs:
         username: ${{secrets.EDX_SMTP_USERNAME}}
         password: ${{secrets.EDX_SMTP_PASSWORD}}
         subject: CI workflow failed in ${{github.repository}}
-        to: teaching-and-learning@edx.opsgenie.net
+        to: tnl-squad@edx.org
         from: github-actions <github-actions@edx.org>
         body: CI workflow in ${{github.repository}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
CI failures in studio-frontend PRs are **not** important enough to warrant an OpsGenie alert. The PR owner must investigate and fix the failures before merging.

My original plan was to remove all notification of these PR CI failures. But this repo doesn't get much activity and instead changed it to a `tnl-squad@edx.org` email.
