### PR TITLE
fix: use npx to run semantic release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-        run: npm semantic-release
+        run: npx semantic-release
 
       - name: Deploy to GH pages
         env:


### PR DESCRIPTION
Release CI is failing because of `npm semantic-release` used in workflow where semantic-release isn't an npm command. Updating it to `npx semantic-release`