### PR TITLE
build: update push translation job

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,7 +15,7 @@
     "i18n": {
       "plugins": [
         ["react-intl", {
-          "messagesDir": "./src/data/i18n/default/",
+          "messagesDir": "./temp/babel-plugin-react-intl",
           "enforceDescriptions": true
         }]
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@
 node_modules
 npm-debug.log
 coverage
+.idea
 
 dist/
 src/data/i18n/default/src/
+temp/babel-plugin-react-intl
+
+## Emacs ###
+*~
+/temp
+/.vscode

--- a/.tx/config
+++ b/.tx/config
@@ -3,6 +3,7 @@ host = https://www.transifex.com
 
 [o:open-edx:p:edx-platform:r:studio-frontend]
 file_filter = src/data/i18n/locales/<lang>.json
+source_file = src/data/i18n/default/transifex_input.json
 source_lang = en_US
 type        = KEYVALUEJSON
 


### PR DESCRIPTION
### [PROD-2742](https://openedx.atlassian.net/browse/PROD-2742)

### Description

- Updating Studio-frontend push translation job to match the other MFEs push translation job
- This is needed to update push translation jobs to use edx/reactifex instead of reactifex. edx/reactifex uses Transifex API v3 for pushing translation string comments instead of API v2.
- In push job, `tx push -s` has been added. Not sure how the translation strings are pushed in studio frontend. The comments suggest that transifex_input.json is being by Transifex but I could not find any reference on [Transifex](https://www.transifex.com/open-edx/edx-platform/studio-frontend/)
- References
   - https://github.com/openedx/frontend-platform/blob/master/src/i18n/scripts/Makefile
   - https://github.com/openedx/frontend-platform/blob/b5f6b0847a2ff774b8bcb9664b2789b0fa9511a8/docs/how_tos/i18n.rst
   - https://github.com/openedx/frontend-app-support-tools/blob/master/Makefile
   - https://github.com/openedx/frontend-build/blob/a8b528da3b8398bfb27935386932a7fca98c7a19/config/babel.config.js