### PR TITLE
Remove email notification after CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,3 @@ jobs:
 
     - name: Run Coverage
       uses: codecov/codecov-action@v2
-
-    - name: Send failure notification
-      if: ${{ failure() }}
-      uses: dawidd6/action-send-mail@v3
-      with:
-        server_address: email-smtp.us-east-1.amazonaws.com
-        server_port: 465
-        username: ${{secrets.EDX_SMTP_USERNAME}}
-        password: ${{secrets.EDX_SMTP_PASSWORD}}
-        subject: CI workflow failed in ${{github.repository}}
-        to: teaching-and-learning@edx.opsgenie.net
-        from: github-actions <github-actions@edx.org>
-        body: CI workflow in ${{github.repository}} failed! For details see "github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-


### PR DESCRIPTION
In this PR: https://github.com/openedx/studio-frontend/pull/316
I changed the email address notified about this repo's CI failures from OpsGenie to a team alias. 

In this PR: https://github.com/openedx/studio-frontend/pull/315
the email address was changed back to the OpsGenie alias.

This PR removes the email notification section altogether. Only the PR creator/owner needs to know about CI failures - and Github will inform them when those failures occur.
