### PR TITLE
`npm run build` script in Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Unit Tests
       run: npm run test
 
+    - name: Build
+      run: npm run build
+
     - name: Validation Checks
       run: ./.github/validate_changes_for_merge.sh
 


### PR DESCRIPTION
### Ticket
[Ensure npm run build is used in MFE repo build workflows](https://github.com/openedx/frontend-wg/issues/33)

### What has changed
Added `npm run build` script in github CI