### PR TITLE
Moving code coverage from codecov package to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
       run: ./.github/validate_changes_for_merge.sh
 
     - name: Run Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "babel-jest": "^23.4.2",
         "babel-loader": "^8.0.0",
         "babel-plugin-react-intl": "^2.3.1",
-        "codecov": "^2.3.0",
         "css-loader": "^0.28.11",
         "enzyme": "^3.3.0",
         "enzyme-adapter-react-16": "^1.1.1",
@@ -5389,15 +5388,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha512-dEamhpPEwRUBpLNHeuCm/v+g0anFByHahxodVO/BbAarHVBBg2MccCwf9K+o1Pof+2btdnkJelYVUWjW/VrATw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.10"
-      }
-    },
     "node_modules/argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -6261,6 +6251,7 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha512-u1L0ZLywRziOVjUhRxI0Qg9G+4RnFB9H/Rq40YWn0dieDgO7vAYeJz6jKAO6t/aruzlDFLAPkQTT87e+f8Imaw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -6385,6 +6376,7 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha512-JnJpAS0p9RmixkOvW2XwDxxzs1bd4/VAGIl6Q0EC5YOo+p+hqIhtDhn/nmFnB/xUNXbLkpE2mOjgVIBRKD4xYw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -7120,6 +7112,7 @@
       "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "hoek": "2.x.x"
       },
@@ -7604,7 +7597,8 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/cast-array": {
       "version": "1.0.1",
@@ -7941,23 +7935,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/codecov": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.3.1.tgz",
-      "integrity": "sha512-nk86gjbYHGia605QaH2xibxPzcTUxNvsVX0gW7nsKSItcZyBeuUeMvGKN5BPZUsI7sJsuhBva70TGjAHus/D+Q==",
-      "dev": true,
-      "dependencies": {
-        "argv": "0.0.2",
-        "request": "2.77.0",
-        "urlgrey": "0.4.4"
-      },
-      "bin": {
-        "codecov": "bin/codecov"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/collection-visit": {
@@ -9029,6 +9006,7 @@
       "integrity": "sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "boom": "2.x.x"
       },
@@ -13734,6 +13712,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha512-8HWGSLAPr+AG0hBpsqi5Ob8HrLStN/LWeqhpFl14d7FJgHK48TmgLoALPz69XSUR65YJzDfLUX/BM8+MLJLghQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.5",
@@ -13872,13 +13851,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha512-X46lB9wLCsgkyagCmX2Dev5od5j6niCr3UeMbXVDBVO4tlpXp3o4OFh+0gPTlkD3ZMixU8PCKxf0IMGQvPo8HQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "is-property": "^1.0.0"
       }
@@ -14318,6 +14299,7 @@
       "integrity": "sha512-P6tFV+wCcUL3nbyTDAvveDySfbhy0XkDtAIfZP6HITjM2WUsiPna/Eg1Yy93SFXvahqoX+kt0n+6xlXKDXYowA==",
       "deprecated": "this library is no longer supported",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chalk": "^1.1.1",
         "commander": "^2.9.0",
@@ -14336,6 +14318,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14345,6 +14328,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -14361,6 +14345,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -14609,6 +14594,7 @@
       "integrity": "sha512-X8xbmTc1cbPXcQV4WkLcRMALuyoxhfpFATmyuCxJPOAvrDS4DNnsTAOmKUxMTOWU6TzrTOkxPKwIx5ZOpJVSrg==",
       "deprecated": "This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "boom": "2.x.x",
         "cryptiles": "2.x.x",
@@ -14645,6 +14631,7 @@
       "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
       "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.40"
       }
@@ -15199,6 +15186,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha512-iUn0NcRULlDGtqNLN1Jxmzayk8ogm7NToldASyZBpM2qggbphjXzNOiw3piN8tgz+e/DRs6X5gAzFwTI6BCRcg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "assert-plus": "^0.2.0",
         "jsprim": "^1.2.2",
@@ -15898,13 +15886,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/is-my-json-valid": {
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -16034,7 +16024,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.0.4",
@@ -17170,6 +17161,7 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha512-K7vR/jmvXsP04hvItAziqPeWmGceLWye9tkqbI+zFCvD4aDnL94BbGHggtQTfqRxbsgGWb4ospGQU8Rd7CEzPg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18549,6 +18541,7 @@
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
       "deprecated": "Use uuid module instead",
       "dev": true,
+      "peer": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -21066,6 +21059,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -21081,16 +21075,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -21105,6 +21102,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -21122,6 +21120,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -27394,6 +27393,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
       "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -28594,6 +28594,7 @@
       "integrity": "sha1-KwDYIDDt7cyXCJ/6XYgQqcKqMUs=",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.6.0",
         "aws4": "^1.2.1",
@@ -30872,6 +30873,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "deprecated": "This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "hoek": "2.x.x"
       },
@@ -32064,7 +32066,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/strip-ansi": {
       "version": "3.0.1",
@@ -33403,6 +33406,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -33813,12 +33817,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
-    },
-    "node_modules/urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
     },
     "node_modules/use": {
@@ -40611,12 +40609,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha512-dEamhpPEwRUBpLNHeuCm/v+g0anFByHahxodVO/BbAarHVBBg2MccCwf9K+o1Pof+2btdnkJelYVUWjW/VrATw==",
-      "dev": true
-    },
     "argv-formatter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -41252,7 +41244,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha512-u1L0ZLywRziOVjUhRxI0Qg9G+4RnFB9H/Rq40YWn0dieDgO7vAYeJz6jKAO6t/aruzlDFLAPkQTT87e+f8Imaw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -41337,7 +41330,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha512-JnJpAS0p9RmixkOvW2XwDxxzs1bd4/VAGIl6Q0EC5YOo+p+hqIhtDhn/nmFnB/xUNXbLkpE2mOjgVIBRKD4xYw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "aws4": {
       "version": "1.11.0",
@@ -41966,6 +41960,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -42385,7 +42380,8 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "cast-array": {
       "version": "1.0.1",
@@ -42661,17 +42657,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "dev": true
-    },
-    "codecov": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.3.1.tgz",
-      "integrity": "sha512-nk86gjbYHGia605QaH2xibxPzcTUxNvsVX0gW7nsKSItcZyBeuUeMvGKN5BPZUsI7sJsuhBva70TGjAHus/D+Q==",
-      "dev": true,
-      "requires": {
-        "argv": "0.0.2",
-        "request": "2.77.0",
-        "urlgrey": "0.4.4"
-      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -43529,6 +43514,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==",
       "dev": true,
+      "peer": true,
       "requires": {
         "boom": "2.x.x"
       }
@@ -47149,6 +47135,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha512-8HWGSLAPr+AG0hBpsqi5Ob8HrLStN/LWeqhpFl14d7FJgHK48TmgLoALPz69XSUR65YJzDfLUX/BM8+MLJLghQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.5",
@@ -47259,13 +47246,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha512-X46lB9wLCsgkyagCmX2Dev5od5j6niCr3UeMbXVDBVO4tlpXp3o4OFh+0gPTlkD3ZMixU8PCKxf0IMGQvPo8HQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "is-property": "^1.0.0"
       }
@@ -47621,6 +47610,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha512-P6tFV+wCcUL3nbyTDAvveDySfbhy0XkDtAIfZP6HITjM2WUsiPna/Eg1Yy93SFXvahqoX+kt0n+6xlXKDXYowA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "chalk": "^1.1.1",
         "commander": "^2.9.0",
@@ -47632,13 +47622,15 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
           "dev": true,
+          "peer": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -47651,7 +47643,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -47837,6 +47830,7 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha512-X8xbmTc1cbPXcQV4WkLcRMALuyoxhfpFATmyuCxJPOAvrDS4DNnsTAOmKUxMTOWU6TzrTOkxPKwIx5ZOpJVSrg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "boom": "2.x.x",
         "cryptiles": "2.x.x",
@@ -47865,7 +47859,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.0",
@@ -48317,6 +48312,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha512-iUn0NcRULlDGtqNLN1Jxmzayk8ogm7NToldASyZBpM2qggbphjXzNOiw3piN8tgz+e/DRs6X5gAzFwTI6BCRcg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "assert-plus": "^0.2.0",
         "jsprim": "^1.2.2",
@@ -48858,13 +48854,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "is-my-json-valid": {
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -48962,7 +48960,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -49978,7 +49977,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha512-K7vR/jmvXsP04hvItAziqPeWmGceLWye9tkqbI+zFCvD4aDnL94BbGHggtQTfqRxbsgGWb4ospGQU8Rd7CEzPg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "JSONStream": {
       "version": "1.3.2",
@@ -51124,7 +51124,8 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "nomnom": {
       "version": "1.6.2",
@@ -53009,7 +53010,8 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -53022,15 +53024,18 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -53042,7 +53047,8 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -53056,7 +53062,8 @@
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",
@@ -58053,7 +58060,8 @@
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
       "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "query-string": {
       "version": "2.4.2",
@@ -59049,6 +59057,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.77.0.tgz",
       "integrity": "sha1-KwDYIDDt7cyXCJ/6XYgQqcKqMUs=",
       "dev": true,
+      "peer": true,
       "requires": {
         "aws-sign2": "~0.6.0",
         "aws4": "^1.2.1",
@@ -60822,6 +60831,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
+      "peer": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -61720,7 +61730,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -62770,7 +62781,8 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -63107,12 +63119,6 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
-    },
-    "urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
-      "dev": true
     },
     "use": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "babel-jest": "^23.4.2",
     "babel-loader": "^8.0.0",
     "babel-plugin-react-intl": "^2.3.1",
-    "codecov": "^2.3.0",
     "css-loader": "^0.28.11",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",


### PR DESCRIPTION
Ticket
[Migrate from Coveralls to Codecov ](https://github.com/openedx/frontend-wg/issues/9)

Codecov NodeJS Uploader [package](https://www.npmjs.com/package/codecov) is depreciated since version 3.8.3

This PR move the coverage to CI according to the new guidelines and [depreciation](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/) plan of codecov 