### PR TITLE
Remove unused tranisfex v2 url 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,6 @@ i18n.preprocess: ## gather all display strings into a single file
 i18n.pre_validate: | i18n.extract i18n.preprocess
 	git diff --exit-code ./src/data/i18n/default/transifex_input.json
 
-tx_url1 = https://www.transifex.com/api/2/project/edx-platform/resource/studio-frontend/translation/en/strings/
-tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/studio-frontend/source/
 # Pushes translations to Transifex.  You must run make extract_translations first.
 push_translations:
 


### PR DESCRIPTION
Ticket:
[Updating /api/v2 transifex endpoints](https://github.com/edx/edx-arch-experiments/issues/202)

There was no need for tx-url1 and tx-url2 because transifex has already migrated from v2 to v3.